### PR TITLE
Remove RHEL 7.5 for SAP due to EoS

### DIFF
--- a/doc_source/launch-wizard-sap-ascs-support-os.md
+++ b/doc_source/launch-wizard-sap-ascs-support-os.md
@@ -5,8 +5,6 @@ The following table provides the details for the operating systems supported by 
 
 | Operating system version | Single\-node deployment | ASCS | ERS | PAS | SAP HANA database | SAP HANA database in HA cluster | 
 | --- | --- | --- | --- | --- | --- | --- | 
-| Red\-Hat\-Enterprise\-Linux\-7\.5\-For\-SAP\-HVM | ✓ | ✓ | ✓ | ✓ |  ✓  | ✓ | 
-| Red\-Hat\-Enterprise\-Linux\-7\.5\-For\-SAP\-HA\-US\-HVM | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | 
 | Red\-Hat\-Enterprise\-Linux\-7\.6\-For\-SAP\-HA\-US\-HVM | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | 
 | SuSE\-Linux\-15\-HVM | ✓ |  |  | ✓ |  |  | 
 | SuSE\-Linux\-15\-For\-SAP\-HVM | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

RHEL release 7.5 is excluded from E4S. The end date for support of RHEL 7.5 for SAP was on 04/30/2020. 

Source:

https://access.redhat.com/articles/3671571
https://access.redhat.com/solutions/3075991

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
