### PR TITLE
Update note about memory requirement and dedi host

### DIFF
--- a/doc_source/launch-wizard-sap-deploying.md
+++ b/doc_source/launch-wizard-sap-deploying.md
@@ -611,7 +611,7 @@ On the **Configure deployment model** page, enter the deployment details for the
    + Under **Instance sizing**, choose **Use AWS recommended resources** or **Choose your instance**\.
      + **Use AWS recommended resources**\.
        + **Infrastructure requirements**\. Choose the requirements for your recommended resources from the dropdown list\.
-         + **Based on CPU/Memory**\. If you select this option, enter the required number of vCPU **Cores** and **Memory**\. Amazon EC2supports up to 448 logical processors\. If the amount of memory required exceeds 4TB, [dedicated hosts](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/dedicated-hosts-overview.html) are required\.
+         + **Based on CPU/Memory**\. If you select this option, enter the required number of vCPU **Cores** and **Memory**\. Amazon EC2supports up to 448 logical processors\. If the required amount of memory exceeds 12TB, [dedicated hosts](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/dedicated-hosts-overview.html) are required\.
          + **SAPS \(SAP Application Performance Standard\)**\. If you select this option, enter the **SAPS** rating for the SAP certified instance types\. 
      + **Choose your instance**\.
        + **Instance type**\. Choose the instance type from the dropdown list\.


### PR DESCRIPTION
Updating public docs as AWS offers On-demand High Memory instances up to 12TB e.g. u-12tb1.112xlarge

https://aws.amazon.com/ec2/instance-types/high-memory/

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
